### PR TITLE
Remove native event listeners when all delegated listeners are removed

### DIFF
--- a/delegated-events.js
+++ b/delegated-events.js
@@ -65,9 +65,12 @@
 
   this.off = function(name, selector, fn) {
     var selectors = events[name];
-    if (selectors) {
-      selectors.remove(selector, fn);
-    }
+    if (!selectors) return;
+    selectors.remove(selector, fn);
+
+    if (selectors.size) return;
+    delete events[name];
+    document.removeEventListener(name, dispatch, false);
   };
 
   this.fire = function(target, name, detail) {

--- a/test/test.js
+++ b/test/test.js
@@ -64,6 +64,17 @@ describe('delegated event listeners', function() {
       $.off('test:event', '*', observer);
       $.fire(document.body, 'test:event');
     });
+
+    it('can reregister after removing', function(done) {
+      var observer = function(event) {
+        assert(true);
+        done();
+      };
+      $.on('test:event', '*', observer);
+      $.off('test:event', '*', observer);
+      $.on('test:event', '*', observer);
+      $.fire(document.body, 'test:event');
+    });
   });
 
   describe('event propagation', function() {


### PR DESCRIPTION
This will reduce memory usage slightly (by allowing the empty SelectorSet to be GCed) and speed up event dispatch (by letting the browser skip calling into JavaScript at all).

I couldn't find a way to test directly whether the native event listener was removed, but I did add a test to show that unregistering and then reregistering for an event does work.