### PR TITLE
Prefer anonymous define()

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,5 +1,4 @@
   {
-    "moduleIds": true,
     "presets": [
       "es2015-rollup"
     ]


### PR DESCRIPTION
Inserting AMD module IDs is usually left as an application/bundler concern. Published packages should be configured as "anonymous modules" so they can be loaded from where the consumer places them.

-
To: @dgraham 