### PR TITLE
Implement capture event listener option

### DIFF
--- a/delegated-events.js
+++ b/delegated-events.js
@@ -57,6 +57,13 @@ function dispatch(event) {
   const events = event.eventPhase === 1 ? captureEvents : bubbleEvents;
   const selectors = events[event.type];
   const queue = matches(selectors, event.target);
+
+  // capture event phase walks propagation path by descending down the tree
+  // rather than walking up.
+  if (event.eventPhase === 1) {
+    queue.reverse();
+  }
+
   for (let i = 0, len1 = queue.length; i < len1; i++) {
     if (propagationStopped.get(event)) break;
     const matched = queue[i];

--- a/delegated-events.js
+++ b/delegated-events.js
@@ -1,6 +1,7 @@
 import SelectorSet from 'selector-set';
 
-const events = {};
+const bubbleEvents = {};
+const captureEvents = {};
 const propagationStopped = new WeakMap();
 const immediatePropagationStopped = new WeakMap();
 const currentTargets = new WeakMap();
@@ -53,6 +54,7 @@ function dispatch(event) {
   before(event, 'stopImmediatePropagation', trackImmediate);
   defineCurrentTarget(event);
 
+  const events = event.eventPhase === 1 ? captureEvents : bubbleEvents;
   const selectors = events[event.type];
   const queue = matches(selectors, event.target);
   for (let i = 0, len1 = queue.length; i < len1; i++) {
@@ -68,17 +70,23 @@ function dispatch(event) {
   currentTargets.delete(event);
 }
 
-export function on(name, selector, fn) {
+export function on(name, selector, fn, options = {}) {
+  const capture = options.capture ? true : false;
+  const events = capture ? captureEvents : bubbleEvents;
+
   let selectors = events[name];
   if (!selectors) {
     selectors = new SelectorSet();
     events[name] = selectors;
-    document.addEventListener(name, dispatch, false);
+    document.addEventListener(name, dispatch, capture);
   }
   selectors.add(selector, fn);
 }
 
-export function off(name, selector, fn) {
+export function off(name, selector, fn, options = {}) {
+  const capture = options.capture ? true : false;
+  const events = capture ? captureEvents : bubbleEvents;
+
   const selectors = events[name];
   if (!selectors) return;
   selectors.remove(selector, fn);

--- a/test/test.js
+++ b/test/test.js
@@ -90,6 +90,8 @@ describe('delegated event listeners', function() {
       const order = [];
 
       const parent = this.parent;
+      const child = this.child;
+
       const one = function(event) {
         assert.strictEqual(child, event.target);
         assert.strictEqual(parent, event.currentTarget);
@@ -98,7 +100,6 @@ describe('delegated event listeners', function() {
         order.push(1);
       };
 
-      const child = this.child;
       const two = function(event) {
         assert.strictEqual(child, event.target);
         assert.strictEqual(child, event.currentTarget);
@@ -107,13 +108,33 @@ describe('delegated event listeners', function() {
         order.push(2);
       };
 
-      on('test:order', '.js-test-parent', one);
-      on('test:order', '.js-test-child', two);
-      fire(this.child, 'test:order');
-      off('test:order', '.js-test-parent', one);
-      off('test:order', '.js-test-child', two);
+      const three = function(event) {
+        assert.strictEqual(child, event.target);
+        assert.strictEqual(parent, event.currentTarget);
+        assert.strictEqual(this, event.currentTarget);
+        assert.strictEqual(this, parent);
+        order.push(3);
+      };
 
-      assert.deepEqual([2, 1], order);
+      const four = function(event) {
+        assert.strictEqual(child, event.target);
+        assert.strictEqual(child, event.currentTarget);
+        assert.strictEqual(this, event.currentTarget);
+        assert.strictEqual(this, child);
+        order.push(4);
+      };
+
+      on('test:order', '.js-test-parent', one, {capture: true});
+      on('test:order', '.js-test-child', two, {capture: true});
+      on('test:order', '.js-test-parent', three);
+      on('test:order', '.js-test-child', four);
+      fire(this.child, 'test:order');
+      off('test:order', '.js-test-parent', one, {capture: true});
+      off('test:order', '.js-test-child', two, {capture: true});
+      off('test:order', '.js-test-parent', three);
+      off('test:order', '.js-test-child', four);
+
+      assert.deepEqual([2, 1, 4, 3], order);
     });
 
     it('clears currentTarget after propagation', function() {

--- a/test/test.js
+++ b/test/test.js
@@ -134,7 +134,7 @@ describe('delegated event listeners', function() {
       off('test:order', '.js-test-parent', three);
       off('test:order', '.js-test-child', four);
 
-      assert.deepEqual([2, 1, 4, 3], order);
+      assert.deepEqual([1, 2, 4, 3], order);
     });
 
     it('clears currentTarget after propagation', function() {


### PR DESCRIPTION
Closes #4.

This adds an additional event listener option object that accepts `capture: true`. Capture events go into a separate event listener selector set. I was able to reuse the existing `dispatch` listener function for both and just condition the set based on the `eventPhase` property.

I'm wondering what other test cases would be useful.

##

To: @dgraham 
CC: @mislav 