### PR TITLE
Add flow type annotations

### DIFF
--- a/delegated-events.js.flow
+++ b/delegated-events.js.flow
@@ -1,0 +1,13 @@
+/* @flow */
+
+type EventHandler = (event: Event) => mixed
+
+type EventListenerOptions = {
+  capture?: boolean
+};
+
+declare module.exports: {
+  on(name: string, selector: string, handler: EventHandler, options?: EventListenerOptions): void;
+  off(name: string, selector: string, handler: EventHandler, options?: EventListenerOptions): void;
+  fire(target: EventTarget, name: string, detail?: any): void;
+};

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "lint": "eslint delegated-events.js test",
     "bootstrap": "git submodule update --init && npm install",
     "prebuild": "npm run lint",
-    "build": "rollup -c rollup.config.dist.js",
+    "build": "rollup -c rollup.config.dist.js && cp delegated-events.js.flow dist/",
     "pretest": "npm run lint && rollup -c rollup.config.test.js",
     "test": "open \"file://$(pwd)/test/test.html\"",
     "prebench": "npm run lint && rollup -c rollup.config.bench.js",
@@ -34,6 +34,7 @@
     "rollup-plugin-node-resolve": "^2.0.0"
   },
   "files": [
+    "delegated-events.js.flow",
     "delegated-events.js",
     "dist"
   ]


### PR DESCRIPTION
To avoid complicating the build scripts, this adds a flow type annotation as a separate `.flow` file. In total the API is only three methods whose type signature shouldn't change very often. We're probably fine maintaining this a separate file for the purposes of this library.

##

CC: @dgraham @mislav @tberman