### PR TITLE
Define special Event type for handlers

### DIFF
--- a/delegated-events.js.flow
+++ b/delegated-events.js.flow
@@ -1,5 +1,23 @@
 /* @flow */
 
+type Event = {
+  bubbles: boolean;
+  cancelable: boolean;
+  currentTarget: Element;
+  deepPath?: () => EventTarget[];
+  defaultPrevented: boolean;
+  eventPhase: number;
+  isTrusted: boolean;
+  scoped: boolean;
+  srcElement: Element;
+  target: Element;
+  timeStamp: number;
+  type: string;
+  preventDefault(): void;
+  stopImmediatePropagation(): void;
+  stopPropagation(): void;
+}
+
 type EventHandler = (event: Event) => mixed
 
 type EventListenerOptions = {

--- a/test/test-flow.js
+++ b/test/test-flow.js
@@ -4,6 +4,7 @@ import {on, off, fire} from '../delegated-events';
 
 function onButtonClick(event) {
   event.target;
+  event.target.closest('.foo');
 }
 
 on('click', '.js-button', onButtonClick);
@@ -11,6 +12,7 @@ off('click', 'js-button', onButtonClick);
 
 on('robot:singularity', '.js-robot-image', function(event) {
   event.target;
+  event.target.closest('.foo');
   // event.detail.name
   // this.src
 });


### PR DESCRIPTION
This imports and customizes an `Event` type used by delegated-event handlers.

Originally copied from flow dom.js https://github.com/facebook/flow/blob/df7d0b797bc93f934befee4362192549190bbcdd/lib/dom.js#L197-L224

Since delegated-event events use `Element.matches`, all its targets must be `Element`s not `EventTarget`s. You'd never have `event.target === window` in an delegated-event handler.

This allows the following to type check:

``` js
on('click', '.js-foo', (event) => {
  event.target.closest('.js-bar')
})
```

##

CC: @tberman