### PR TITLE
Silence exception in Microsoft Edge

### DIFF
--- a/delegated-events.js.flow
+++ b/delegated-events.js.flow
@@ -28,4 +28,5 @@ declare module.exports: {
   on(name: string, selector: string, handler: EventHandler, options?: EventListenerOptions): void;
   off(name: string, selector: string, handler: EventHandler, options?: EventListenerOptions): void;
   fire(target: EventTarget, name: string, detail?: any): void;
+  onMismatchedEventType((type: string, event: Event) => any): void;
 };


### PR DESCRIPTION
Edge 14–15 seems to have a browser bug where a `dispatchEvent()` for a custom event can trigger the event handler that was installed for a different event type. Because of delegated-events internals, this mismatch causes a runtime exception with an unfriendly message. (Note: I was never able to actually reproduce this myself.)

This PR introduces a guard that detects when this happens, silences the exception, and aborts the event handler. It also introduces a new method `onMismatchedEventType()` that can be used to install a debugging handler to report these exceptions somewhere as an alternative to simply silencing them.

The diff is best viewed with`?w=1`.