### PR TITLE
Ensure currentTarget property is configurable

### DIFF
--- a/delegated-events.js
+++ b/delegated-events.js
@@ -84,7 +84,11 @@ function dispatch(event) {
   }
 
   currentTargets.delete(event);
-  defineCurrentTarget(event, currentTargetDesc);
+  defineCurrentTarget(event, {
+    configurable: true,
+    enumerable: true,
+    get: currentTargetDesc.get
+  });
 }
 
 export function on(name, selector, fn, options = {}) {

--- a/test/test.js
+++ b/test/test.js
@@ -160,7 +160,7 @@ describe('delegated event listeners', function() {
       on('test:clear', 'body', observer);
       document.body.dispatchEvent(event);
       assert.equal(trace.calls, 1);
-      assert.isNull(event.currentTarget);
+      assert.equal(event.currentTarget, null);
       off('test:clear', 'body', observer);
     });
 
@@ -179,7 +179,7 @@ describe('delegated event listeners', function() {
       this.child.dispatchEvent(event);
       assert.equal(trace.calls, 1);
       assert.equal(trace2.calls, 1);
-      assert.isNull(event.currentTarget);
+      assert.equal(event.currentTarget, null);
 
       off('test:target:capture', 'body', observer, {capture: true});
       this.parent.removeEventListener('test:target:capture', observer2);
@@ -196,7 +196,7 @@ describe('delegated event listeners', function() {
 
       document.body.dispatchEvent(event);
       assert.equal(trace.calls, 1);
-      assert.isNull(event.currentTarget);
+      assert.equal(event.currentTarget, null);
 
       off('test:currentTarget', '.not-body', one);
       document.removeEventListener('test:currentTarget', observer);


### PR DESCRIPTION
Safari 9.1 returns false for configurable so extract only the getter from the property descriptor.

This prevents an error when attempting to configure the property again through a second event dispatch, like when first dispatching through a capture phase followed by a bubbling phase. However, currentTarget will still be null when referenced by a native addEventListener handler after the delegated loop finishes.