### PR TITLE
TypeScript: Make currentTarget non-nullable

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,6 @@
-export function on<K extends keyof GlobalEventHandlersEventMap>(name: K, selector: string, listener: (this: GlobalEventHandlers, ev: GlobalEventHandlersEventMap[K]) => any, options?: EventListenerOptions): void;
-export function on(name: string, selector: string, listener: EventListener, options?: EventListenerOptions): void;
-export function off(name: string, selector: string, listener: EventListener, options?: EventListenerOptions): void;
-export function fire(target: EventTarget, name: string, detail?: any): boolean;
+type DelegatedEventListener = (this: Element, ev: CustomEvent & {currentTarget: Element}) => any
+
+export function on<K extends keyof GlobalEventHandlersEventMap>(name: K, selector: string, listener: (this: GlobalEventHandlers & Element, ev: GlobalEventHandlersEventMap[K] & {currentTarget: Element}) => any, options?: EventListenerOptions): void;
+export function on(name: string, selector: string, listener: DelegatedEventListener, options?: EventListenerOptions): void;
+export function off(name: string, selector: string, listener: DelegatedEventListener, options?: EventListenerOptions): void;
+export function fire(target: Element, name: string, detail?: any): boolean;


### PR DESCRIPTION
Ports flow type change made in https://github.com/dgraham/delegated-events/pull/7 to TypeScript annotation file.

Makes it okay to write code like

```js
import {on} from 'delegated-events'

on('click', '.foo', function(event) {
  this.classList.toggle('on')
  event.currentTarget.classList.toggle('on')
})
```

Since `currentTarget` must always be an Element that implements `.matches` to have passed the CSS selector check.

##

To: @dgraham 
CC: @koddsson @muan @myobie