### PR TITLE
Allow events to bubble outside of ShadowDOM

### DIFF
--- a/delegated-events.js
+++ b/delegated-events.js
@@ -121,6 +121,7 @@ export function fire(target, name, detail) {
     new CustomEvent(name, {
       bubbles: true,
       cancelable: true,
+      composed: true,
       detail: detail
     })
   );

--- a/delegated-events.js.flow
+++ b/delegated-events.js.flow
@@ -3,6 +3,7 @@
 type Event = {
   bubbles: boolean;
   cancelable: boolean;
+  composed: boolean;
   currentTarget: Element;
   deepPath?: () => EventTarget[];
   defaultPrevented: boolean;

--- a/test/bench.js
+++ b/test/bench.js
@@ -111,6 +111,7 @@ import {on, off} from '../delegated-events';
         new CustomEvent('test:bench', {
           bubbles: true,
           cancelable: true,
+          composed: true,
           detail: {index: i}
         })
       );

--- a/test/test.js
+++ b/test/test.js
@@ -15,6 +15,7 @@ describe('delegated event listeners', function() {
       const observer = function(event) {
         assert(event.bubbles);
         assert(event.cancelable);
+        assert(event.composed);
         assert.equal(event.type, 'test:detail');
         assert.deepEqual(event.detail, {id: 42, login: 'hubot'});
         assert.strictEqual(document.body, event.target);
@@ -58,6 +59,7 @@ describe('delegated event listeners', function() {
       const observer = function(event) {
         assert(event.bubbles);
         assert(event.cancelable);
+        assert(event.composed);
         assert.equal(event.type, 'test:on');
         assert.deepEqual({id: 42, login: 'hubot'}, event.detail);
         assert.strictEqual(document.body, event.target);


### PR DESCRIPTION
Hello!

Events firing from within a custom element with a shadow-root by default stop bubbling at said root.
This PR makes it so events bubble all the way up, without stopping.