### PR TITLE
Permission denied to access property eventPhase

### DIFF
--- a/delegated-events.js
+++ b/delegated-events.js
@@ -62,9 +62,19 @@ function defineCurrentTarget(event, getter) {
   });
 }
 
-function dispatch(event) {
-  const events = event.eventPhase === 1 ? captureEvents : bubbleEvents;
+function canDispatch(event) {
+  try {
+    event.eventPhase;
+    return true;
+  } catch (_) {
+    return false;
+  }
+}
 
+function dispatch(event) {
+  if (!canDispatch(event)) return;
+
+  const events = event.eventPhase === 1 ? captureEvents : bubbleEvents;
   const selectors = events[event.type];
   if (!selectors) return;
 


### PR DESCRIPTION
> There was an attempt to access an object for which you have no permission.
—https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/Property_access_denied

This is a frequent exception from Firefox browsers with extensions that inject third-party scripts. The script dispatches an event that bubbles up to the document listener which tries to access its eventPhase property. This is not allowed because the event was generated from a third-party origin.

So attempt to read the property from the event, while catching errors, to determine if we're allowed to use it. This seems like something the browser should shield from the first-party site but here we are.