### PR TITLE
docs: add readme note about using TypeScript custom overloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ declare module 'delegated-events' {
     name: K,
     selector: string,
     listener: CustomDelegatedEventListener<CustomEventMap[K]>
-  ): boolean
+  ): void
 }
 
 declare global {

--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ declare global {
   interface HTMLElement {
     addEventListener<K extends keyof CustomEventMap>(
       type: K,
-      listener: (this: Document, ev: CustomEvent<CustomEventMap[K]>) => unknown,
+      listener: (this: HTMLElement, ev: CustomEvent<CustomEventMap[K]>) => unknown,
       options?: boolean | AddEventListenerOptions
     ): void
   }


### PR DESCRIPTION
### What?

This adds a note in the readme about overloading this modules functions to support typed custom events.

### Why?

Following https://github.com/dgraham/delegated-events/issues/34#issuecomment-659996550 I thought I'd make it more evident that users are able to overload `delegated-events` from within their TypeScript projects.