### PR TITLE
Fix the typescript type definition for `fire`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -3,4 +3,4 @@ type DelegatedEventListener = (this: Element, ev: CustomEvent & {currentTarget: 
 export function on<K extends keyof GlobalEventHandlersEventMap>(name: K, selector: string, listener: (this: GlobalEventHandlers & Element, ev: GlobalEventHandlersEventMap[K] & {currentTarget: Element}) => any, options?: EventListenerOptions): void;
 export function on(name: string, selector: string, listener: DelegatedEventListener, options?: EventListenerOptions): void;
 export function off(name: string, selector: string, listener: DelegatedEventListener, options?: EventListenerOptions): void;
-export function fire(target: Document | Element, name: string, detail?: any): boolean;
+export function fire(target: EventTarget, name: string, detail?: any): boolean;


### PR DESCRIPTION
Allowing any `EventTarget` matches the Flow type definitions